### PR TITLE
Fix Beacon iOS build error

### DIFF
--- a/Beacon.xcframework/ios-arm64/Beacon.framework/Headers/HSBeacon.h
+++ b/Beacon.xcframework/ios-arm64/Beacon.framework/Headers/HSBeacon.h
@@ -1,5 +1,5 @@
 #import <UIKit/UIKit.h>
-@import UserNotifications;
+#import <UserNotifications/UserNotifications.h>
 
 @protocol HSBeaconSuggestionItem;
 @class HSBeaconUser;

--- a/Beacon.xcframework/ios-arm64/Beacon.framework/Headers/HSBeaconFocusMode.h
+++ b/Beacon.xcframework/ios-arm64/Beacon.framework/Headers/HSBeaconFocusMode.h
@@ -1,4 +1,4 @@
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 /// HSBeaconFocusMode represents various configuration modes of Beacon.
 /// Allowing you to customize the experience your users have, from getting in contact

--- a/Beacon.xcframework/ios-arm64_x86_64-simulator/Beacon.framework/Headers/HSBeacon.h
+++ b/Beacon.xcframework/ios-arm64_x86_64-simulator/Beacon.framework/Headers/HSBeacon.h
@@ -1,5 +1,5 @@
 #import <UIKit/UIKit.h>
-@import UserNotifications;
+#import <UserNotifications/UserNotifications.h>
 
 @protocol HSBeaconSuggestionItem;
 @class HSBeaconUser;

--- a/Beacon.xcframework/ios-arm64_x86_64-simulator/Beacon.framework/Headers/HSBeaconFocusMode.h
+++ b/Beacon.xcframework/ios-arm64_x86_64-simulator/Beacon.framework/Headers/HSBeaconFocusMode.h
@@ -1,4 +1,4 @@
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 /// HSBeaconFocusMode represents various configuration modes of Beacon.
 /// Allowing you to customize the experience your users have, from getting in contact


### PR DESCRIPTION
Beacon was erroring out on build because the original code has ObjC and C++ mixed in one file and XCode was not respecting the build settings, this PR fixes it.